### PR TITLE
헤로쿠 DB 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
-  jpa.hibernate.ddl-auto: validate
-  sql.init.mode: never
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa.hibernate.ddl-auto: create
+  sql.init.mode: always


### PR DESCRIPTION
ClearDB -> JawsDB로 변경
조사해본 결과, cleardb의 기본 mysql 버전이 '5.6' 너무 낮기 때문에 대안으로 jawsdb를 찾아냄. ('5.6' 버전에서는 'article_comment.content' 인덱스 사이즈가 너무 큼)
기본 mysql 버전 '8.0'
이를 이용해 환경변수를 다시 작업.

This fixes #42 